### PR TITLE
feat: detect provider by host IP, drop AKASH_PROVIDER_ADDRESS env

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ akash tx deployment create deploy.yml --from <key>
 
 The page tries two strategies, in order:
 
-1. `AKASH_PROVIDER_ADDRESS` env — set this in your SDL to pin the answer explicitly.
-2. Fall back to geolocating the container's public IP (via [ipapi.co](https://ipapi.co)) and finding the geographically closest provider by Haversine distance.
+1. Look up the container's public IP (via [ipapi.co](https://ipapi.co)), then resolve each provider's `hostUri` via DNS and look for an exact IP match. When deployed on Akash, the workload's egress IP usually matches the provider's host IP.
+2. If no host IP matches (provider uses a separate egress gateway, or the page is running off-Akash), fall back to the geographically closest provider by Haversine distance.
 
 If both fail, the banner is hidden and the globe renders normally.
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -10,12 +10,12 @@ export function ThemeToggle() {
   useEffect(() => setMounted(true), []);
 
   const isDark = resolvedTheme === "dark";
-  const label = isDark ? "Switch to light theme" : "Switch to dark theme";
+  const label = mounted ? (isDark ? "Switch to light theme" : "Switch to dark theme") : "Toggle theme";
 
   return (
     <button
       type="button"
-      onClick={() => setTheme(isDark ? "light" : "dark")}
+      onClick={() => mounted && setTheme(isDark ? "light" : "dark")}
       aria-label={label}
       title={label}
       className="btn btn-ghost fixed right-4 top-4 z-50 !h-9 !w-9 !p-0 backdrop-blur"

--- a/src/lib/current-provider.spec.ts
+++ b/src/lib/current-provider.spec.ts
@@ -41,60 +41,96 @@ describe("detectCurrentProvider", () => {
     expect(result).toBeNull();
   });
 
-  it("prefers AKASH_PROVIDER_ADDRESS over IP geolocation", async () => {
-    const providers: ProviderMarker[] = [marker("eu", 50, 8), marker("pinned", 0, 0)];
-    const fetchImpl = vi.fn();
-    const result = await detectCurrentProvider(providers, { env: { AKASH_PROVIDER_ADDRESS: "pinned" }, fetchImpl });
-    expect(result?.source).toBe("env");
-    expect(result?.marker.owner).toBe("pinned");
-    expect(fetchImpl).not.toHaveBeenCalled();
+  it("returns ip-host match when our public IP resolves to a provider's hostUri", async () => {
+    const providers: ProviderMarker[] = [
+      marker("eu", 50, 8, "https://provider.eu.example:8443"),
+      marker("us", 39, -77, "https://provider.us.example:8443")
+    ];
+    const fetchImpl = mockGeoResponse({ ip: "203.0.113.10", latitude: 50.1, longitude: 8.6 });
+    const dnsLookup = vi.fn(async (hostname: string) => {
+      if (hostname === "provider.us.example") return { address: "203.0.113.10", family: 4 };
+      return { address: "198.51.100.1", family: 4 };
+    });
+
+    const result = await detectCurrentProvider(providers, { fetchImpl, dnsLookup });
+
+    expect(result?.source).toBe("ip-host");
+    expect(result?.marker.owner).toBe("us");
+    expect(result?.publicIp).toBe("203.0.113.10");
   });
 
-  it("ignores an AKASH_PROVIDER_ADDRESS that doesn't match any provider and falls back to geolocation", async () => {
-    const providers: ProviderMarker[] = [marker("eu", 50, 8)];
-    const fetchImpl = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ip: "1.2.3.4", latitude: 50.1, longitude: 8.6 }), {
-        status: 200,
-        headers: { "content-type": "application/json" }
-      })
-    );
-    const result = await detectCurrentProvider(providers, { env: { AKASH_PROVIDER_ADDRESS: "unknown" }, fetchImpl });
+  it("falls back to geographically closest provider when no host IP matches", async () => {
+    const providers: ProviderMarker[] = [
+      marker("eu", 50, 8, "https://provider.eu.example:8443"),
+      marker("us", 39, -77, "https://provider.us.example:8443")
+    ];
+    const fetchImpl = mockGeoResponse({ ip: "1.2.3.4", latitude: 50.1, longitude: 8.6 });
+    const dnsLookup = vi.fn(async () => ({ address: "198.51.100.1", family: 4 }));
+
+    const result = await detectCurrentProvider(providers, { fetchImpl, dnsLookup });
+
     expect(result?.source).toBe("ip-geo");
     expect(result?.marker.owner).toBe("eu");
+    expect(result?.publicIp).toBe("1.2.3.4");
+  });
+
+  it("tolerates DNS failures on individual providers", async () => {
+    const providers: ProviderMarker[] = [
+      marker("broken", 50, 8, "https://broken.example:8443"),
+      marker("us", 39, -77, "https://provider.us.example:8443")
+    ];
+    const fetchImpl = mockGeoResponse({ ip: "203.0.113.10", latitude: 39, longitude: -77 });
+    const dnsLookup = vi.fn(async (hostname: string) => {
+      if (hostname === "broken.example") throw new Error("ENOTFOUND");
+      return { address: "203.0.113.10", family: 4 };
+    });
+
+    const result = await detectCurrentProvider(providers, { fetchImpl, dnsLookup });
+
+    expect(result?.source).toBe("ip-host");
+    expect(result?.marker.owner).toBe("us");
   });
 
   it("returns null when geolocation lookup fails", async () => {
-    const providers: ProviderMarker[] = [marker("eu", 50, 8)];
+    const providers: ProviderMarker[] = [marker("eu", 50, 8, "https://provider.eu.example:8443")];
     const fetchImpl = vi.fn().mockRejectedValue(new Error("network"));
-    const result = await detectCurrentProvider(providers, { env: {}, fetchImpl });
+    const dnsLookup = vi.fn();
+
+    const result = await detectCurrentProvider(providers, { fetchImpl, dnsLookup });
+
     expect(result).toBeNull();
+    expect(dnsLookup).not.toHaveBeenCalled();
   });
 
   it("returns null when geolocation response has no coordinates", async () => {
-    const providers: ProviderMarker[] = [marker("eu", 50, 8)];
-    const fetchImpl = vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "rate limited" }), { status: 200, headers: { "content-type": "application/json" } }));
-    const result = await detectCurrentProvider(providers, { env: {}, fetchImpl });
-    expect(result).toBeNull();
-  });
-
-  it("picks the closest provider by Haversine when geolocation succeeds", async () => {
-    const providers: ProviderMarker[] = [marker("eu", 50, 8), marker("us", 39, -77), marker("sg", 1.35, 103)];
+    const providers: ProviderMarker[] = [marker("eu", 50, 8, "https://provider.eu.example:8443")];
     const fetchImpl = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ip: "1.1.1.1", latitude: 37.77, longitude: -122.41 }), {
+      new Response(JSON.stringify({ error: "rate limited" }), {
         status: 200,
         headers: { "content-type": "application/json" }
       })
     );
-    const result = await detectCurrentProvider(providers, { env: {}, fetchImpl });
-    expect(result?.marker.owner).toBe("us");
-    expect(result?.publicIp).toBe("1.1.1.1");
+
+    const result = await detectCurrentProvider(providers, { fetchImpl, dnsLookup: vi.fn() });
+
+    expect(result).toBeNull();
   });
 });
 
-function marker(owner: string, lat: number, lng: number): ProviderMarker {
+function mockGeoResponse(body: { ip: string; latitude: number; longitude: number }) {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    })
+  );
+}
+
+function marker(owner: string, lat: number, lng: number, hostUri = `https://${owner}.example:8443`): ProviderMarker {
   return {
     owner,
     name: owner,
+    hostUri,
     lat,
     lng,
     region: "",

--- a/src/lib/current-provider.ts
+++ b/src/lib/current-provider.ts
@@ -1,49 +1,103 @@
+import { lookup as dnsLookup } from "node:dns/promises";
+
 import type { ProviderMarker } from "@/lib/types";
 
 const IP_TIMEOUT_MS = 4000;
+const DNS_TIMEOUT_MS = 2000;
 
 export interface CurrentProvider {
   marker: ProviderMarker;
-  source: "env" | "ip-geo";
+  source: "ip-host" | "ip-geo";
   publicIp?: string;
 }
 
+export type DnsLookupFn = (hostname: string) => Promise<{ address: string; family: number }>;
+
 export interface DetectDeps {
   fetchImpl?: typeof fetch;
-  env?: Record<string, string | undefined>;
+  dnsLookup?: DnsLookupFn;
 }
 
 /**
  * Best-effort detection of the Akash provider hosting this container.
  *
  * Strategy:
- *   1. Honour `AKASH_PROVIDER_ADDRESS` if set (operator can pin it explicitly via SDL env).
- *   2. Otherwise, look up the server's public IP and find the geographically closest provider.
+ *   1. Look up our public IP, then resolve each provider's hostUri via DNS and match exactly.
+ *   2. If no host IP matches, fall back to the geographically closest provider by Haversine.
  *
  * Returns null on any failure — the page renders fine without a "you are here" marker.
  */
 export async function detectCurrentProvider(providers: ProviderMarker[], deps: DetectDeps = {}): Promise<CurrentProvider | null> {
   if (providers.length === 0) return null;
 
-  const env = deps.env ?? process.env;
   const fetchImpl = deps.fetchImpl ?? fetch;
+  const lookup = deps.dnsLookup ?? defaultDnsLookup;
 
-  const pinnedAddress = env.AKASH_PROVIDER_ADDRESS?.trim();
-  if (pinnedAddress) {
-    const match = providers.find(p => p.owner === pinnedAddress);
-    if (match) return { marker: match, source: "env" };
-  }
-
+  let ipInfo: ServerLocation | null;
   try {
-    const ipInfo = await fetchServerLocation(fetchImpl);
-    if (!ipInfo) return null;
-    const closest = findClosest(providers, ipInfo.lat, ipInfo.lng);
-    if (!closest) return null;
-    return { marker: closest, source: "ip-geo", publicIp: ipInfo.ip };
+    ipInfo = await fetchServerLocation(fetchImpl);
+  } catch {
+    return null;
+  }
+  if (!ipInfo) return null;
+
+  const hostMatch = await findByHostIp(providers, ipInfo.ip, lookup);
+  if (hostMatch) return { marker: hostMatch, source: "ip-host", publicIp: ipInfo.ip };
+
+  const closest = findClosest(providers, ipInfo.lat, ipInfo.lng);
+  if (!closest) return null;
+  return { marker: closest, source: "ip-geo", publicIp: ipInfo.ip };
+}
+
+async function findByHostIp(providers: ProviderMarker[], publicIp: string, lookup: DnsLookupFn): Promise<ProviderMarker | null> {
+  const target = normalizeIp(publicIp);
+  if (!target) return null;
+
+  const lookups = providers.map(async provider => {
+    const hostname = extractHostname(provider.hostUri);
+    if (!hostname) return null;
+    try {
+      const result = await withTimeout(lookup(hostname), DNS_TIMEOUT_MS);
+      if (!result?.address) return null;
+      return normalizeIp(result.address) === target ? provider : null;
+    } catch {
+      return null;
+    }
+  });
+
+  const results = await Promise.all(lookups);
+  return results.find((p): p is ProviderMarker => p !== null) ?? null;
+}
+
+function extractHostname(hostUri: string): string | null {
+  if (!hostUri) return null;
+  try {
+    return new URL(hostUri).hostname;
   } catch {
     return null;
   }
 }
+
+function normalizeIp(ip: string): string {
+  return ip.trim().replace(/^\[|\]$/g, "").toLowerCase();
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("timeout")), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+const defaultDnsLookup: DnsLookupFn = async hostname => {
+  const result = await dnsLookup(hostname);
+  return { address: result.address, family: result.family };
+};
 
 interface ServerLocation {
   ip: string;

--- a/src/lib/providers.spec.ts
+++ b/src/lib/providers.spec.ts
@@ -73,6 +73,11 @@ describe("buildSnapshot", () => {
     expect(result.providers[0].name).not.toBe("");
     expect(result.providers[0].name).toContain("…");
   });
+
+  it("preserves hostUri on the marker so detection can resolve it", () => {
+    const result = buildSnapshot([makeProvider({ hostUri: "https://provider.eu.example:8443" })], new Date());
+    expect(result.providers[0].hostUri).toBe("https://provider.eu.example:8443");
+  });
 });
 
 describe("getNetworkSnapshot", () => {

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -71,6 +71,7 @@ function toMarker(p: ApiProvider): ProviderMarker {
   return {
     owner: p.owner,
     name: p.name?.trim() || shortenAddress(p.owner),
+    hostUri: p.hostUri,
     lat,
     lng,
     region: p.ipRegion ?? "",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,7 @@ export interface ApiProvider {
 export interface ProviderMarker {
   owner: string;
   name: string;
+  hostUri: string;
   lat: number;
   lng: number;
   region: string;


### PR DESCRIPTION
## Summary

- **Drop the `AKASH_PROVIDER_ADDRESS` env-var pin path.** It's effectively dead — the public image (`ghcr.io/akash-network/hello-akash-world`) is meant to be deployed by anyone with no per-provider config, and operators rarely know (or bother to set) their on-chain owner address.
- **Replace it with exact host-IP matching.** Resolve each provider's `hostUri` hostname via DNS (`node:dns/promises.lookup`, in parallel, 2s per-lookup timeout) and compare to the container's public IP from ipapi.co. When deployed on Akash, a workload's egress IP usually matches the provider's host IP, so this gives an unambiguous match instead of the "geographically closest" approximation.
- **Keep the closest-by-geo path as a fallback** for providers using a separate egress gateway, and for off-Akash local dev. Detection failure still returns `null` → plain globe, no banner (unchanged UX).
- **Fix a `ThemeToggle` hydration mismatch** picked up while testing this branch: `aria-label`/`title` were derived from `resolvedTheme`, which is `undefined` on the server and resolved on the client, causing React's hydration warning. Gate the label on `mounted` (same pattern already used for the icon).

### Changes
- `src/lib/current-provider.ts` — rewrite detection: drop env branch, add `findByHostIp()` with parallel DNS resolution, IPv4/IPv6 normalization, per-lookup timeout. `CurrentProvider.source` literal becomes `"ip-host" | "ip-geo"`. New `DetectDeps.dnsLookup` injection seam for tests.
- `src/lib/types.ts` — add `hostUri` to `ProviderMarker`.
- `src/lib/providers.ts` — `toMarker()` passes `hostUri` through.
- `src/lib/current-provider.spec.ts` — replace the two AKASH_PROVIDER_ADDRESS tests with three new ones (host-IP match, no-match → geo fallback, per-provider DNS failure tolerance).
- `src/lib/providers.spec.ts` — add `hostUri` round-trip assertion.
- `README.md` — rewrite the "Running on this provider" section.
- `src/components/ThemeToggle.tsx` — gate label on `mounted`.

## Test plan

- [x] `npm test` — 24/24 passing locally (includes 3 new detection tests)
- [x] `npm run typecheck` — clean
- [x] `grep AKASH_PROVIDER_ADDRESS` returns no hits anywhere in the repo
- [ ] Smoke `npm run dev` and confirm no hydration warning in the browser console
- [ ] After merge + image rebuild: deploy to two Akash providers in different countries; verify each shows the *correct* provider name in the Hero banner with `source: "ip-host"`. If a provider uses a separate egress gateway, expect `source: "ip-geo"` with a believable nearby provider.