### PR TITLE
fix(ci): build arm64 on native runners to unblock v2.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,11 @@ env:
   IMAGE_NAME: akash-network/hello-akash-world
 
 jobs:
-  build:
-    name: Build & publish Docker image
+  resolve:
+    name: Resolve image tag
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,6 +48,77 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Publishing tag: ${tag}"
 
+  build:
+    name: Build ${{ matrix.platform }}
+    needs: resolve
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            platform_pair: linux-amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_pair: linux-arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.platform_pair }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform_pair }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform_pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge multi-arch manifest
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -62,17 +135,16 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ steps.tag.outputs.tag }}
+            type=raw,value=${{ needs.resolve.outputs.tag }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
             type=sha,prefix=sha-,format=short,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.resolve.outputs.tag }}


### PR DESCRIPTION
## Summary
- **Root cause of the v2.1.0 release failure:** the previous `Release` workflow built both `linux/amd64` and `linux/arm64` on `ubuntu-latest` via QEMU. The arm64 build crashed with `Next.js build worker exited with code: null and signal: SIGILL` — Next.js's native SWC binaries are unreliable under QEMU. amd64 finished, arm64 died, so the multi-arch push was aborted and no `ghcr.io/akash-network/hello-akash-world:2.1.0` image was published. Failed run: https://github.com/akash-network/hello-akash-world/actions/runs/26119132528
- **Fix:** build each platform on a native runner (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64 — free on public repos), push each arch by digest, then a `merge` job stitches them into a single multi-arch manifest with the same tag set as before (`{version}`, `latest`, `sha-{short}`). Per-platform GHA cache scopes prevent the two builds from clobbering each other.
- Bonus: significantly faster than QEMU cross-build.

Once this lands on `main`, the push triggers `Release` and (since `package.json` is still `2.1.0`) publishes the previously-missed v2.1.0 image.

## Test plan
- [ ] Merge to `main`
- [ ] Confirm the `Release` workflow run on the merge commit completes (both `Build linux/amd64` and `Build linux/arm64` matrix jobs + `Merge multi-arch manifest`)
- [ ] Verify `ghcr.io/akash-network/hello-akash-world:2.1.0` and `:latest` are present and multi-arch via `docker buildx imagetools inspect ghcr.io/akash-network/hello-akash-world:2.1.0`